### PR TITLE
Fix proc-v7.S #alloc #execinstr

### DIFF
--- a/arch/arm/boot/compressed/piggy.gzip.S
+++ b/arch/arm/boot/compressed/piggy.gzip.S
@@ -1,4 +1,4 @@
-	.section .piggydata,#alloc
+        .section .piggydata,"a"
 	.globl	input_data
 input_data:
 	.incbin	"arch/arm/boot/compressed/piggy.gzip"

--- a/arch/arm/boot/compressed/piggy.lzma.S
+++ b/arch/arm/boot/compressed/piggy.lzma.S
@@ -1,4 +1,4 @@
-	.section .piggydata,#alloc
+        .section .piggydata,"a"
 	.globl	input_data
 input_data:
 	.incbin	"arch/arm/boot/compressed/piggy.lzma"

--- a/arch/arm/boot/compressed/piggy.lzo.S
+++ b/arch/arm/boot/compressed/piggy.lzo.S
@@ -1,4 +1,4 @@
-	.section .piggydata,#alloc
+        .section .piggydata,"a"
 	.globl	input_data
 input_data:
 	.incbin	"arch/arm/boot/compressed/piggy.lzo"

--- a/arch/arm/boot/compressed/piggy.xzkern.S
+++ b/arch/arm/boot/compressed/piggy.xzkern.S
@@ -1,4 +1,4 @@
-	.section .piggydata,#alloc
+        .section .piggydata,"a"
 	.globl	input_data
 input_data:
 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"

--- a/arch/arm/mm/proc-v7.S
+++ b/arch/arm/mm/proc-v7.S
@@ -343,7 +343,7 @@ __v7_setup_stack:
 	string	cpu_elf_name, "v7"
 	.align
 
-	.section ".proc.info.init", #alloc, #execinstr
+	.section ".proc.info.init", "ax"
 
 	/*
 	 * Standard v7 proc info content

--- a/fs/sdfat/sdfat.c
+++ b/fs/sdfat/sdfat.c
@@ -1181,6 +1181,7 @@ static int sdfat_create(struct inode *dir, struct dentry *dentry, umode_t mode,
 {
 	return __sdfat_create(dir, dentry);
 }
+#endif
 
 /*************************************************************************
  * WRAP FUNCTIONS FOR DEBUGGING


### PR DESCRIPTION
Hello. I'm trying to build your `lineage-18.1` branch with PostmarketOS `pmbootstrap build`.
It uses Alpine linux GCC 6.

I'm getting this error:
```
arch/arm/mm/proc-v7.S: Assembler messages:
arch/arm/mm/proc-v7.S:346: Error: junk at end of line, first unrecognized character is `#'
make[1]: *** [scripts/Makefile.build:343: arch/arm/mm/proc-v7.o] Error 1
make: *** [Makefile:952: arch/arm/mm] Error 2
```
